### PR TITLE
Remove call to AppAreaListPlugin

### DIFF
--- a/src/Plugin/FixSeoUrlParsing.php
+++ b/src/Plugin/FixSeoUrlParsing.php
@@ -43,7 +43,6 @@ class FixSeoUrlParsing
     }
 
     /**
-     * Obtain modified URL from \Ho\StoreResolver\Plugin\AppAreaListPlugin for correct handling of SEO URLs
      *
      * @param                  $subject
      * @param \Closure         $proceed
@@ -64,11 +63,7 @@ class FixSeoUrlParsing
             return false;
         }
 
-        if (AppAreaListPlugin::getModifiedOriginalPathInfo()) {
-            $identifier = ltrim(AppAreaListPlugin::getModifiedOriginalPathInfo(), '/');
-        } else {
-            $identifier = ltrim($request->getOriginalPathInfo(), '/');
-        }
+        $identifier = ltrim($request->getOriginalPathInfo(), '/');
         if (!empty($identifier)) {
             foreach (self::SKIP_REQUEST_IDENTIFIERS as $skipRequestIdentifier) {
                 if (strpos($identifier, $skipRequestIdentifier) === 0) {


### PR DESCRIPTION
I think this is from a previous version (see https://github.com/ho-nl/magento2-ReachDigital_StoreResolver/commit/7ef479d8cd84e5a32c75479fa21a72ac1e188506) but the `AppAreaListPlugin` doesn't exist anymore. Not sure if required, so just removed it to avoid crashing directly.

(Probably only an issue when using the Amasty ShopBy module)