### PR TITLE
Check urlStoreId as integer

### DIFF
--- a/src/Model/AppResponseRedirect.php
+++ b/src/Model/AppResponseRedirect.php
@@ -61,9 +61,11 @@ class AppResponseRedirect extends \Magento\Store\App\Response\Redirect
         // Determine if URL is within current store
         if ($url !== null && strpos($url, 'http') !== false) {
             $urlStoreId = $this->storeResolver->getStoreForUrl($url);
-            $curStoreId = (int) $this->_storeManager->getStore()->getId();
+            if ($urlStoreId !== false) {
+                $curStoreId = (int) $this->_storeManager->getStore()->getId();
 
-            return $urlStoreId === $curStoreId;
+                return (int) $urlStoreId === $curStoreId;
+            }
         }
 
         return false;


### PR DESCRIPTION
It seems that the `$urlStoreId` is returned as a string (so `"2"`). The curStoreId is cast as int and it is a strict comparison, so it fails.
The result can also be false, so I added a check for that case. Otherwise we also cast it as an int.

This fixes #19, as it marks the url incorrectly as not being internal, which make the 'backUrl' revert to the current store url (the homepage).